### PR TITLE
Fix script crash when mqtt user and passwword is set

### DIFF
--- a/waveshare_ups.py
+++ b/waveshare_ups.py
@@ -92,7 +92,7 @@ def Main():
             print("MQTT: Username is valid, but password is None")
             print("MQTT: Not using authentication")
         else:
-            Client.username_ps_set(Uname,Pword)
+            Client.username_pw_set(Uname,Pword)
 
     #Last Will and Testament
     Client.will_set(Topic,"{\"Status\": 0}",0,True)


### PR DESCRIPTION
python3 /usr/local/bin/waveshare_ups.py
CONFIG: Opening file  /etc/waveshare_ups.yaml
CONFIG: The entire configuration structure is  {......}
CONFIG: Hostname is openhab
UPS: Configured INA219 at address 66 for 32V 2A
MQTT: Topic is ups/openhab
Traceback (most recent call last):
  File "/usr/local/bin/waveshare_ups.py", line 193, in <module>
    Main()
  File "/usr/local/bin/waveshare_ups.py", line 95, in Main
    Client.username_ps_set(Uname,Pword)
AttributeError: 'Client' object has no attribute 'username_ps_set'